### PR TITLE
Adding analysis of entitlements file, embedded frameworks, watch app and App Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,14 @@ Or install it as a system-wide GEM / CLI:
 
 If used as a CLI:
 
-    ipa_analyzer -i /path/to/app.ipa -p --info-plist --prov
+    ipa_analyzer -i /path/to/app.ipa -p --info-plist --prov --entitlements --frameworks
 
-This will collect and print both the embedded mobileprovisioning
-and the Info.plist, in a pretty printed JSON output.
+This will collect and print:
+* the embedded mobileprovisioning,
+* the Info.plist, 
+* the entitlements (from the Entitlements.plist or archived-expanded-entitlements.xcent files) if any,
+* the list of frameworks if any
+in a pretty printed JSON output.
 
 The output of this command looks like this:
 
@@ -106,6 +110,82 @@ The output of this command looks like this:
             "UIInterfaceOrientationPortraitUpsideDown",
             "UIInterfaceOrientationLandscapeLeft",
             "UIInterfaceOrientationLandscapeRight"
+          ]
+        }
+      },
+      "frameworks": {
+        "path_in_ipa": "Payload/MyApp.app/Frameworks",
+        "content": [
+          {
+            "filename": "Payload/MyApp.app/Frameworks/PodExample1.framework/Info.plist",
+            "content": {
+              "BuildMachineOSBuild": "14F27",
+              "CFBundleDevelopmentRegion": "en",
+              "CFBundleExecutable": "PodExample1",
+              "CFBundleIdentifier": "org.cocoapods.PodExample1",
+              "CFBundleInfoDictionaryVersion": "6.0",
+              "CFBundleName": "PodExample1",
+              "CFBundlePackageType": "FMWK",
+              "CFBundleShortVersionString": "3.1.2",
+              "CFBundleSignature": "????",
+              "CFBundleSupportedPlatforms": [
+                "iPhoneOS"
+              ],
+              "CFBundleVersion": "1",
+              "DTCompiler": "com.apple.compilers.llvm.clang.1_0",
+              "DTPlatformBuild": "13C75",
+              "DTPlatformName": "iphoneos",
+              "DTPlatformVersion": "9.2",
+              "DTSDKBuild": "13C75",
+              "DTSDKName": "iphoneos9.2",
+              "DTXcode": "0720",
+              "DTXcodeBuild": "7C68",
+              "MinimumOSVersion": "9.0",
+              "UIDeviceFamily": [
+                1,
+                2
+              ]
+            }
+          },
+          {
+            "filename": "Payload/MyApp.app/Frameworks/PodExample2.framework/Info.plist",
+            "content": {
+              "BuildMachineOSBuild": "14F27",
+              "CFBundleDevelopmentRegion": "en",
+              "CFBundleExecutable": "PodExample2",
+              "CFBundleIdentifier": "org.cocoapods.PodExample2",
+              "CFBundleInfoDictionaryVersion": "6.0",
+              "CFBundleName": "PodExample2",
+              "CFBundlePackageType": "FMWK",
+              "CFBundleShortVersionString": "2.3.2",
+              "CFBundleSignature": "????",
+              "CFBundleSupportedPlatforms": [
+                "iPhoneOS"
+              ],
+              "CFBundleVersion": "1",
+              "DTCompiler": "com.apple.compilers.llvm.clang.1_0",
+              "DTPlatformBuild": "13C75",
+              "DTPlatformName": "iphoneos",
+              "DTPlatformVersion": "9.2",
+              "DTSDKBuild": "13C75",
+              "DTSDKName": "iphoneos9.2",
+              "DTXcode": "0720",
+              "DTXcodeBuild": "7C68",
+              "MinimumOSVersion": "9.0",
+              "UIDeviceFamily": [
+                1,
+                2
+              ]
+            }
+          }
+        ]
+      },
+      "entitlements": {
+        "path_in_ipa": "Payload/MyApp.app/Entitlements.plist",
+        "content": {
+          "application-identifier": "XXXA8V3XXX.com.company.MyApp",
+          "keychain-access-groups": [
+            "XXXA8V3XXX.com.company.MyApp"
           ]
         }
       }

--- a/README.md
+++ b/README.md
@@ -20,14 +20,18 @@ Or install it as a system-wide GEM / CLI:
 
 If used as a CLI:
 
-    ipa_analyzer -i /path/to/app.ipa -p --info-plist --prov --entitlements --frameworks
+    ipa_analyzer -i /path/to/app.ipa -p --info-plist --prov --entitlements --frameworks --appex --watch
 
 This will collect and print:
 * the embedded mobileprovisioning,
 * the Info.plist, 
 * the entitlements (from the Entitlements.plist or archived-expanded-entitlements.xcent files) if any,
-* the list of frameworks if any
+* the list of frameworks and their Info.plist if any
+* the Info.plist and embedded mobileprovisioning for the embedded Watch app if any
+* the Info.plist and embedded mobileprovisioning for the app extensions if any
 in a pretty printed JSON output.
+
+NOTE: You can also use the shorthand '--all' which automatically includes all switches.
 
 The output of this command looks like this:
 
@@ -188,6 +192,450 @@ The output of this command looks like this:
             "XXXA8V3XXX.com.company.MyApp"
           ]
         }
+      },
+      "app_extensions": [
+        {
+          "path_in_ipa": "Payload/MyApp.app/PlugIns/AppEx1.appex/",
+          "mobileprovision": {
+            "AppIDName": "AppEx1",
+            "ApplicationIdentifierPrefix": [
+              "XXXA8V3XXX"
+            ],
+            "CreationDate": "2017-01-31T18:02:00+00:00",
+            "Platform": [
+              "iOS"
+            ],
+            "Entitlements": {
+              "keychain-access-groups": [
+                "XXXA8V3XXX.*"
+              ],
+              "get-task-allow": false,
+              "application-identifier": "XXXA8V3XXX.com.company.MyApp.AppEx1",
+              "com.apple.developer.team-identifier": "XXXA8V3XXX"
+            },
+            "ExpirationDate": "2018-01-31T18:02:00+00:00",
+            "Name": "com.company.MyApp.AppEx1 PP",
+            "ProvisionsAllDevices": "true",
+            "TeamIdentifier": [
+              "XXXA8V3XXX"
+            ],
+            "TeamName": "Company",
+            "TimeToLive": "365",
+            "UUID": "XXX-3D5D-4BCC-9288-XXX",
+            "Version": "1"
+          },
+          "entitlements": {
+            "application-identifier": "XXXA8V3XXX.com.company.MyApp.AppEx1",
+            "keychain-access-groups": [
+              "XXXA8V3XXX.com.company.MyApp.AppEx1"
+            ]
+          },
+          "info_plist": {
+            "BuildMachineOSBuild": "16A323",
+            "CFBundleDevelopmentRegion": "en",
+            "CFBundleDisplayName": "AppEx1",
+            "CFBundleExecutable": "AppEx1",
+            "CFBundleIdentifier": "com.company.MyApp.AppEx1",
+            "CFBundleInfoDictionaryVersion": "6.0",
+            "CFBundleName": "AppEx1",
+            "CFBundlePackageType": "XPC!",
+            "CFBundleShortVersionString": "1.0",
+            "CFBundleSupportedPlatforms": [
+              "iPhoneOS"
+            ],
+            "CFBundleVersion": "1",
+            "DTCompiler": "com.apple.compilers.llvm.clang.1_0",
+            "DTPlatformBuild": "14B72",
+            "DTPlatformName": "iphoneos",
+            "DTPlatformVersion": "10.1",
+            "DTSDKBuild": "14B72",
+            "DTSDKName": "iphoneos10.1",
+            "DTXcode": "0810",
+            "DTXcodeBuild": "8B62",
+            "MinimumOSVersion": "10.0",
+            "NSExtension": {
+              "NSExtensionAttributes": {
+                "UNNotificationExtensionCategory": "com.company.yesno",
+                "UNNotificationExtensionDefaultContentHidden": true,
+                "UNNotificationExtensionInitialContentSizeRatio": 0.3
+              },
+              "NSExtensionMainStoryboard": "MainInterface",
+              "NSExtensionPointIdentifier": "com.apple.usernotifications.content-extension"
+            },
+            "UIDeviceFamily": [
+              1
+            ]
+          },
+          "plugins": [
+
+          ]
+        },
+        {
+          "path_in_ipa": "Payload/MyApp.app/PlugIns/AppEx2.appex/",
+          "mobileprovision": {
+            "AppIDName": "AppEx2",
+            "ApplicationIdentifierPrefix": [
+              "XXXA8V3XXX"
+            ],
+            "CreationDate": "2017-01-31T18:01:00+00:00",
+            "Platform": [
+              "iOS"
+            ],
+            "Entitlements": {
+              "keychain-access-groups": [
+                "XXXA8V3XXX.*"
+              ],
+              "get-task-allow": false,
+              "application-identifier": "XXXA8V3XXX.com.company.MyApp.AppEx2",
+              "com.apple.security.application-groups": [
+                "group.company.test"
+              ],
+              "com.apple.developer.team-identifier": "XXXA8V3XXX"
+            },
+            "ExpirationDate": "2018-01-31T18:01:00+00:00",
+            "Name": "com.company.MyApp.AppEx2",
+            "ProvisionsAllDevices": "true",
+            "TeamIdentifier": [
+              "XXXA8V3XXX"
+            ],
+            "TeamName": "Company",
+            "TimeToLive": "365",
+            "UUID": "XXX-3D5D-4BCC-9288-XXX",
+            "Version": "1"
+          },
+          "entitlements": {
+            "com.apple.security.application-groups": [
+              "group.company.test"
+            ]
+          },
+          "info_plist": {
+            "BuildMachineOSBuild": "16A323",
+            "CFBundleDevelopmentRegion": "en",
+            "CFBundleDisplayName": "AppEx2",
+            "CFBundleExecutable": "AppEx2",
+            "CFBundleIdentifier": "com.company.MyApp.AppEx2",
+            "CFBundleInfoDictionaryVersion": "6.0",
+            "CFBundleName": "AppEx2",
+            "CFBundlePackageType": "XPC!",
+            "CFBundleShortVersionString": "1.0",
+            "CFBundleSignature": "????",
+            "CFBundleSupportedPlatforms": [
+              "iPhoneOS"
+            ],
+            "CFBundleVersion": "1",
+            "DTCompiler": "com.apple.compilers.llvm.clang.1_0",
+            "DTPlatformBuild": "14B72",
+            "DTPlatformName": "iphoneos",
+            "DTPlatformVersion": "10.1",
+            "DTSDKBuild": "14B72",
+            "DTSDKName": "iphoneos10.1",
+            "DTXcode": "0810",
+            "DTXcodeBuild": "8B62",
+            "MinimumOSVersion": "10.0",
+            "NSExtension": {
+              "NSExtensionAttributes": {
+                "IntentsRestrictedWhileLocked": [
+
+                ],
+                "IntentsSupported": [
+                  "INGetRideStatusIntent",
+                  "INListRideOptionsIntent",
+                  "INRequestRideIntent"
+                ]
+              },
+              "NSExtensionPointIdentifier": "com.apple.intents-service",
+              "NSExtensionPrincipalClass": "AppEx2.IntentHandler"
+            },
+            "UIDeviceFamily": [
+              1
+            ]
+          },
+          "plugins": [
+
+          ]
+        },
+        {
+          "path_in_ipa": "Payload/MyApp.app/PlugIns/AppEx3.appex/",
+          "mobileprovision": {
+            "AppIDName": "AppEx3",
+            "ApplicationIdentifierPrefix": [
+              "XXXA8V3XXX"
+            ],
+            "CreationDate": "2017-01-31T18:01:10+00:00",
+            "Platform": [
+              "iOS"
+            ],
+            "Entitlements": {
+              "keychain-access-groups": [
+                "XXXA8V3XXX.*"
+              ],
+              "get-task-allow": false,
+              "application-identifier": "XXXA8V3XXX.com.company.MyApp.AppEx3",
+              "com.apple.security.application-groups": [
+                "group.company.test"
+              ],
+              "com.apple.developer.team-identifier": "XXXA8V3XXX"
+            },
+            "ExpirationDate": "2018-01-31T18:01:10+00:00",
+            "Name": "AppEx3",
+            "ProvisionsAllDevices": "true",
+            "TeamIdentifier": [
+              "XXXA8V3XXX"
+            ],
+            "TeamName": "Company",
+            "TimeToLive": "365",
+            "UUID": "XXX-3D5D-4BCC-9288-XXX",
+            "Version": "1"
+          },
+          "entitlements": {
+            "com.apple.security.application-groups": [
+              "group.company.test"
+            ]
+          },
+          "info_plist": {
+            "BuildMachineOSBuild": "16A323",
+            "CFBundleDevelopmentRegion": "en",
+            "CFBundleDisplayName": "AppEx3",
+            "CFBundleExecutable": "AppEx3",
+            "CFBundleIdentifier": "com.company.MyApp.AppEx3",
+            "CFBundleInfoDictionaryVersion": "6.0",
+            "CFBundleName": "AppEx3",
+            "CFBundlePackageType": "XPC!",
+            "CFBundleShortVersionString": "1.0",
+            "CFBundleSignature": "????",
+            "CFBundleSupportedPlatforms": [
+              "iPhoneOS"
+            ],
+            "CFBundleVersion": "1",
+            "DTCompiler": "com.apple.compilers.llvm.clang.1_0",
+            "DTPlatformBuild": "14B72",
+            "DTPlatformName": "iphoneos",
+            "DTPlatformVersion": "10.1",
+            "DTSDKBuild": "14B72",
+            "DTSDKName": "iphoneos10.1",
+            "DTXcode": "0810",
+            "DTXcodeBuild": "8B62",
+            "MinimumOSVersion": "10.0",
+            "NSExtension": {
+              "NSExtensionAttributes": {
+                "IntentsSupported": [
+                  "INListRideOptionsIntent",
+                  "INRequestRideIntent",
+                  "INGetRideStatusIntent"
+                ]
+              },
+              "NSExtensionMainStoryboard": "MainInterface",
+              "NSExtensionPointIdentifier": "com.apple.intents-ui-service"
+            },
+            "UIDeviceFamily": [
+              1
+            ]
+          },
+          "plugins": [
+
+          ]
+        }
+      ],
+      "watch": {
+        "path_in_ipa": "Payload/MyApp.app/Watch/MyApp WatchKit App.app/",
+        "mobileprovision": {
+          "AppIDName": "WTBeta",
+          "ApplicationIdentifierPrefix": [
+            "XXXA8V3XXX"
+          ],
+          "CreationDate": "2017-01-31T15:31:24+00:00",
+          "Platform": [
+            "iOS"
+          ],
+          "Entitlements": {
+            "keychain-access-groups": [
+              "XXXA8V3XXX.*"
+            ],
+            "get-task-allow": true,
+            "application-identifier": "XXXA8V3XXX.*",
+            "com.apple.developer.ubiquity-kvstore-identifier": "XXXA8V3XXX.*",
+            "com.apple.developer.icloud-services": "*",
+            "com.apple.developer.icloud-container-environment": [
+              "Development",
+              "Production"
+            ],
+            "com.apple.developer.icloud-container-identifiers": [
+
+            ],
+            "com.apple.developer.icloud-container-development-container-identifiers": [
+
+            ],
+            "com.apple.developer.ubiquity-container-identifiers": [
+
+            ],
+            "com.apple.developer.team-identifier": "XXXA8V3XXX",
+            "aps-environment": "development"
+          },
+          "ExpirationDate": "2018-01-31T15:31:24+00:00",
+          "Name": "iOS Team Provisioning Profile: *",
+          "ProvisionedDevices": [
+            "XXX9F698E6E7753EF90B71485ADDC701F37DAXXX",
+            "XXXEA28BF2DDF3A35BEB9A4E72231AD5B9104XXX",
+            "XXXE65C5CADAFF06B56164787B21CBD7AD5B8XXX"
+          ],
+          "TeamIdentifier": [
+            "XXXA8V3XXX"
+          ],
+          "TeamName": "Company",
+          "TimeToLive": "365",
+          "UUID": "bb710fd2-23fd-4c59-9264-4e52125dad02",
+          "Version": "1"
+        },
+        "entitlements": {
+          "application-identifier": "XXXA8V3XXX.com.company.application.iphone.watch-app",
+          "keychain-access-groups": [
+            "XXXA8V3XXX.com.company.application.iphone.watch-app"
+          ]
+        },
+        "info_plist": {
+          "BuildMachineOSBuild": "15G1004",
+          "CFBundleDevelopmentRegion": "en",
+          "CFBundleDisplayName": "MyApp",
+          "CFBundleExecutable": "MyApp WatchKit App",
+          "CFBundleIcons": {
+            "CFBundlePrimaryIcon": {
+              "CFBundleIconFiles": [
+                "AppIcon24x24",
+                "AppIcon27.5x27.5",
+                "AppIcon29x29",
+                "AppIcon40x40",
+                "AppIcon86x86",
+                "AppIcon98x98"
+              ]
+            }
+          },
+          "CFBundleIdentifier": "com.company.application.iphone.watch-app",
+          "CFBundleInfoDictionaryVersion": "6.0",
+          "CFBundleName": "MyApp WatchKit App",
+          "CFBundlePackageType": "APPL",
+          "CFBundleShortVersionString": "3.4.1",
+          "CFBundleSignature": "????",
+          "CFBundleSupportedPlatforms": [
+            "WatchOS"
+          ],
+          "CFBundleVersion": "2016121201-debug",
+          "DTCompiler": "com.apple.compilers.llvm.clang.1_0",
+          "DTPlatformBuild": "13S660",
+          "DTPlatformName": "watchos",
+          "DTPlatformVersion": "2.1",
+          "DTSDKBuild": "13S660",
+          "DTSDKName": "watchos2.1",
+          "DTXcode": "0721",
+          "DTXcodeBuild": "7C1002",
+          "MinimumOSVersion": "2.0",
+          "UIDeviceFamily": [
+            4
+          ],
+          "UISupportedInterfaceOrientations": [
+            "UIInterfaceOrientationPortrait",
+            "UIInterfaceOrientationPortraitUpsideDown"
+          ],
+          "WKCompanionAppBundleIdentifier": "com.company.application.iphone",
+          "WKWatchKitApp": "true"
+        },
+        "plugins": [
+          {
+            "path_in_ipa": "Payload/MyApp.app/Watch/MyApp WatchKit App.app/PlugIns/MyApp WatchKit App Extension.appex/",
+            "mobileprovision": {
+              "AppIDName": "WTBeta",
+              "ApplicationIdentifierPrefix": [
+                "XXXA8V3XXX"
+              ],
+              "CreationDate": "2017-01-31T15:31:24+00:00",
+              "Platform": [
+                "iOS"
+              ],
+              "Entitlements": {
+                "keychain-access-groups": [
+                  "XXXA8V3XXX.*"
+                ],
+                "get-task-allow": true,
+                "application-identifier": "XXXA8V3XXX.*",
+                "com.apple.developer.ubiquity-kvstore-identifier": "XXXA8V3XXX.*",
+                "com.apple.developer.icloud-services": "*",
+                "com.apple.developer.icloud-container-environment": [
+                  "Development",
+                  "Production"
+                ],
+                "com.apple.developer.icloud-container-identifiers": [
+
+                ],
+                "com.apple.developer.icloud-container-development-container-identifiers": [
+
+                ],
+                "com.apple.developer.ubiquity-container-identifiers": [
+
+                ],
+                "com.apple.developer.team-identifier": "XXXA8V3XXX",
+                "aps-environment": "development"
+              },
+              "ExpirationDate": "2018-01-31T15:31:24+00:00",
+              "Name": "iOS Team Provisioning Profile: *",
+              "ProvisionedDevices": [
+                "XXX9F698E6E7753EF90B71485ADDC701F37DAXXX",
+                "XXXEA28BF2DDF3A35BEB9A4E72231AD5B9104XXX",
+                "XXXE65C5CADAFF06B56164787B21CBD7AD5B8XXX"
+              ],
+              "TeamIdentifier": [
+                "XXXA8V3XXX"
+              ],
+              "TeamName": "Company",
+              "TimeToLive": "365",
+              "UUID": "bb710fd2-23fd-4c59-9264-4e52125dad02",
+              "Version": "1"
+            },
+            "entitlements": {
+              "application-identifier": "XXXA8V3XXX.com.company.application.iphone.watch-app.watch-extension",
+              "keychain-access-groups": [
+                "XXXA8V3XXX.com.company.application.iphone.watch-app.watch-extension"
+              ]
+            },
+            "info_plist": {
+              "BuildMachineOSBuild": "15G1004",
+              "CFBundleDevelopmentRegion": "en",
+              "CFBundleDisplayName": "MyApp WatchKit App Extension",
+              "CFBundleExecutable": "MyApp WatchKit App Extension",
+              "CFBundleIdentifier": "com.company.application.iphone.watch-app.watch-extension",
+              "CFBundleInfoDictionaryVersion": "6.0",
+              "CFBundleName": "MyApp WatchKit App Extension",
+              "CFBundlePackageType": "XPC!",
+              "CFBundleShortVersionString": "3.4.1",
+              "CFBundleSignature": "????",
+              "CFBundleSupportedPlatforms": [
+                "WatchOS"
+              ],
+              "CFBundleVersion": "2016121201-debug",
+              "DTCompiler": "com.apple.compilers.llvm.clang.1_0",
+              "DTPlatformBuild": "13S660",
+              "DTPlatformName": "watchos",
+              "DTPlatformVersion": "2.1",
+              "DTSDKBuild": "13S660",
+              "DTSDKName": "watchos2.1",
+              "DTXcode": "0721",
+              "DTXcodeBuild": "7C1002",
+              "MinimumOSVersion": "2.0",
+              "NSExtension": {
+                "NSExtensionAttributes": {
+                  "WKAppBundleIdentifier": "com.company.application.iphone.watch-app"
+                },
+                "NSExtensionPointIdentifier": "com.apple.watchkit"
+              },
+              "RemoteInterfacePrincipalClass": "MyAppMainInferfaceController",
+              "UIDeviceFamily": [
+                4
+              ],
+              "WKExtensionDelegateClassName": "ExtensionDelegate"
+            },
+            "plugins": [
+
+            ]
+          }
+        ]
       }
     }
 

--- a/bin/ipa_analyzer
+++ b/bin/ipa_analyzer
@@ -14,7 +14,12 @@ options = {
   is_verbose: false,
   is_pretty: false,
   is_collect_provision_info: false,
-  is_collect_info_plist: false
+  is_collect_info_plist: false,
+  is_collect_frameworks: false,
+  is_collect_entitlements: false,
+  is_collect_watch: false,
+  is_collect_app_extensions: false,
+  is_collect_all: false
 }
 
 opt_parser = OptionParser.new do |opt|
@@ -24,6 +29,10 @@ opt_parser = OptionParser.new do |opt|
 
   opt.on('-i', '--ipa IPA_PATH', '*IPA file path') do |value|
     options[:ipa_path] = value
+  end
+
+  opt.on('--all', 'Collect maximum information from the IPA') do
+    options[:is_collect_all] = true
   end
 
   opt.on('--prov', 'Collect Provisioning Profile (mobileprovision) information from the IPA') do
@@ -40,6 +49,14 @@ opt_parser = OptionParser.new do |opt|
 
   opt.on('--entitlements', 'Collect Entitlements information from the IPA') do
     options[:is_collect_entitlements] = true
+  end
+
+  opt.on('--appex', 'Collect App Extensions information from the IPA') do
+    options[:is_collect_app_extensions] = true
+  end
+
+  opt.on('--watch', 'Collect Watch information from the IPA') do
+    options[:is_collect_watch] = true
   end
 
   opt.on('-v', '--verbose', 'Verbose output') do
@@ -86,25 +103,35 @@ begin
   vputs ' * Opening the IPA'
   ipa_analyzer.open!
 
-  if options[:is_collect_provision_info]
+  if options[:is_collect_all] || options[:is_collect_provision_info]
     vputs ' * Collecting Provisioning Profile information'
     parsed_infos[:mobileprovision] = ipa_analyzer.collect_provision_info
     raise 'Failed to collect Provisioning Profile information' if parsed_infos[:mobileprovision].nil?
   end
-  if options[:is_collect_info_plist]
+  if options[:is_collect_all] || options[:is_collect_info_plist]
     vputs ' * Collecting Info.plist information'
     parsed_infos[:info_plist] = ipa_analyzer.collect_info_plist_info
     raise 'Failed to collect Info.plist information' if parsed_infos[:info_plist].nil?
   end
 
-  if options[:is_collect_frameworks]
+  if options[:is_collect_all] || options[:is_collect_frameworks]
     vputs ' * Collecting Frameworks information'
     parsed_infos[:frameworks] = ipa_analyzer.collect_frameworks_info
   end
 
-  if options[:is_collect_entitlements]
+  if options[:is_collect_all] || options[:is_collect_entitlements]
     vputs ' * Collecting Entitlements information'
     parsed_infos[:entitlements] = ipa_analyzer.collect_entitlements_info
+  end
+
+  if options[:is_collect_all] || options[:is_collect_watch]
+    vputs ' * Collecting Watch information'
+    parsed_infos[:watch] = ipa_analyzer.collect_watch_info
+  end
+
+  if options[:is_collect_all] || options[:is_collect_app_extensions]
+    vputs ' * Collecting App Extensions information'
+    parsed_infos[:app_extensions] = ipa_analyzer.collect_app_extensions_info
   end
 
 rescue => ex

--- a/bin/ipa_analyzer
+++ b/bin/ipa_analyzer
@@ -3,111 +3,125 @@
 require 'optparse'
 require 'json'
 
-$:.push File.expand_path("../../lib", __FILE__)
+$LOAD_PATH.push File.expand_path('../../lib', __FILE__)
 require 'ipa_analyzer'
-
 
 # -------------------------
 # --- Options
 
 options = {
-	ipa_path: nil,
-	is_verbose: false,
-	is_pretty: false,
-	is_collect_provision_info: false,
-	is_collect_info_plist: false
+  ipa_path: nil,
+  is_verbose: false,
+  is_pretty: false,
+  is_collect_provision_info: false,
+  is_collect_info_plist: false
 }
 
 opt_parser = OptionParser.new do |opt|
-	opt.banner = "Usage: ipa_analyzer.rb [OPTIONS]"
-	opt.separator  ""
-	opt.separator  "Options, the ones marked with * are required"
+  opt.banner = 'Usage: ipa_analyzer.rb [OPTIONS]'
+  opt.separator  ''
+  opt.separator  'Options, the ones marked with * are required'
 
-	opt.on("-i","--ipa IPA_PATH", "*IPA file path") do |value|
-		options[:ipa_path] = value
-	end
+  opt.on('-i', '--ipa IPA_PATH', '*IPA file path') do |value|
+    options[:ipa_path] = value
+  end
 
-	opt.on("--prov","Collect Provisioning Profile (mobileprovision) information from the IPA") do
-		options[:is_collect_provision_info] = true
-	end
+  opt.on('--prov', 'Collect Provisioning Profile (mobileprovision) information from the IPA') do
+    options[:is_collect_provision_info] = true
+  end
 
-	opt.on("--info-plist","Collect Info.plist information from the IPA") do
-		options[:is_collect_info_plist] = true
-	end
+  opt.on('--info-plist', 'Collect Info.plist information from the IPA') do
+    options[:is_collect_info_plist] = true
+  end
 
-	opt.on("-v","--verbose","Verbose output") do
-		options[:is_verbose] = true
-	end
+  opt.on('--frameworks', 'Collect Frameworks information from the IPA') do
+    options[:is_collect_frameworks] = true
+  end
 
-	opt.on("-p","--pretty","Pretty print output") do
-		options[:is_pretty] = true
-	end
+  opt.on('--entitlements', 'Collect Entitlements information from the IPA') do
+    options[:is_collect_entitlements] = true
+  end
 
-	opt.on("-h","--help","Shows this help message") do
-		puts opt_parser
-		exit 0
-	end
+  opt.on('-v', '--verbose', 'Verbose output') do
+    options[:is_verbose] = true
+  end
+
+  opt.on('-p', '--pretty', 'Pretty print output') do
+    options[:is_pretty] = true
+  end
+
+  opt.on('-h', '--help', 'Shows this help message') do
+    puts opt_parser
+    exit 0
+  end
 end
 
 opt_parser.parse!
 $options = options
 
-
 # -------------------------
 # --- Utils
 
-def vputs(msg="")
-	if $options[:is_verbose]
-		puts msg
-	end
+def vputs(msg = '')
+  puts msg if $options[:is_verbose]
 end
-
 
 # -------------------------
 # --- Main
 
 vputs "options: #{options}"
 
-raise "No IPA specified" unless options[:ipa_path]
-raise "IPA specified but file does not exist at the provided path" unless File.exist? options[:ipa_path]
+raise 'No IPA specified' unless options[:ipa_path]
+raise 'IPA specified but file does not exist at the provided path' unless File.exist? options[:ipa_path]
 
 parsed_infos = {
-	mobileprovision: nil,
-	info_plist: nil
+  mobileprovision: nil,
+  info_plist: nil
 }
 
 exit_code = 0
 
 ipa_analyzer = IpaAnalyzer::Analyzer.new(options[:ipa_path])
 begin
-	vputs " * Opening the IPA"
-	ipa_analyzer.open!
+  vputs ' * Opening the IPA'
+  ipa_analyzer.open!
 
-	if options[:is_collect_provision_info]
-		vputs " * Collecting Provisioning Profile information"
-		parsed_infos[:mobileprovision] = ipa_analyzer.collect_provision_info()
-		raise "Failed to collect Provisioning Profile information" if parsed_infos[:mobileprovision].nil?
-	end
-	if options[:is_collect_info_plist]
-		vputs " * Collecting Info.plist information"
-		parsed_infos[:info_plist] = ipa_analyzer.collect_info_plist_info()
-		raise "Failed to collect Info.plist information" if parsed_infos[:info_plist].nil?
-	end
+  if options[:is_collect_provision_info]
+    vputs ' * Collecting Provisioning Profile information'
+    parsed_infos[:mobileprovision] = ipa_analyzer.collect_provision_info
+    raise 'Failed to collect Provisioning Profile information' if parsed_infos[:mobileprovision].nil?
+  end
+  if options[:is_collect_info_plist]
+    vputs ' * Collecting Info.plist information'
+    parsed_infos[:info_plist] = ipa_analyzer.collect_info_plist_info
+    raise 'Failed to collect Info.plist information' if parsed_infos[:info_plist].nil?
+  end
+
+  if options[:is_collect_frameworks]
+    vputs ' * Collecting Frameworks information'
+    parsed_infos[:frameworks] = ipa_analyzer.collect_frameworks_info
+  end
+
+  if options[:is_collect_entitlements]
+    vputs ' * Collecting Entitlements information'
+    parsed_infos[:entitlements] = ipa_analyzer.collect_entitlements_info
+  end
+
 rescue => ex
-	puts
-	puts "Failed: #{ex}"
-	puts
-	exit_code = 1
-	raise ex
+  puts
+  puts "Failed: #{ex}"
+  puts
+  exit_code = 1
+  raise ex
 ensure
-	vputs " * Closing the IPA"
-	ipa_analyzer.close()
+  vputs ' * Closing the IPA'
+  ipa_analyzer.close
 end
 
 if options[:is_pretty]
-	puts JSON.pretty_generate(parsed_infos)
+  puts JSON.pretty_generate(parsed_infos)
 else
-	puts JSON.generate(parsed_infos)
+  puts JSON.generate(parsed_infos)
 end
 
 exit exit_code

--- a/lib/ipa_analyzer/analyzer.rb
+++ b/lib/ipa_analyzer/analyzer.rb
@@ -4,151 +4,194 @@ require 'zip/filesystem'
 require 'plist'
 
 module IpaAnalyzer
-	class Analyzer
-		def initialize(ipa_path)
-			@ipa_path = ipa_path
-			@ipa_zipfile = nil
-			@app_folder_path = nil
-		end
+  class Analyzer
+    def initialize(ipa_path)
+      @ipa_path = ipa_path
+      @ipa_zipfile = nil
+      @app_folder_path = nil
+    end
 
-		def open!
-			@ipa_zipfile = Zip::File.open(@ipa_path)
-			@app_folder_path = find_app_folder_in_ipa()
-			raise "No app folder found in the IPA" if @app_folder_path.nil?
-		end
+    def open!
+      @ipa_zipfile = Zip::File.open(@ipa_path)
+      @app_folder_path = find_app_folder_in_ipa
+      raise 'No app folder found in the IPA' if @app_folder_path.nil?
+    end
 
-		def open?
-			return !@ipa_zipfile.nil?
-		end
+    def open?
+      !@ipa_zipfile.nil?
+    end
 
-		def close
-			if self.open?
-				@ipa_zipfile.close()
-			end
-		end
+    def close
+      @ipa_zipfile.close if open?
+    end
 
-		def collect_provision_info
-			raise "IPA is not open" unless self.open?
+    def collect_provision_info
+      raise 'IPA is not open' unless open?
 
-			result = {
-				path_in_ipa: nil,
-				content: {}
-			}
-			mobileprovision_path = "#{@app_folder_path}/embedded.mobileprovision"
-			mobileprovision_entry = @ipa_zipfile.find_entry(mobileprovision_path)
+      result = {
+        path_in_ipa: nil,
+        content: {}
+      }
+      mobileprovision_path = "#{@app_folder_path}/embedded.mobileprovision"
+      mobileprovision_entry = @ipa_zipfile.find_entry(mobileprovision_path)
 
-			raise "Embedded mobile provisioning file not found in (#{@ipa_path}) at path (#{mobileprovision_path})" unless mobileprovision_entry
-			result[:path_in_ipa] = "#{mobileprovision_entry}"
+      raise "Embedded mobile provisioning file not found in (#{@ipa_path}) at path (#{mobileprovision_path})" unless mobileprovision_entry
+      result[:path_in_ipa] = mobileprovision_entry.to_s
 
-			tempfile = Tempfile.new(::File.basename(mobileprovision_entry.name))
-			begin
-				@ipa_zipfile.extract(mobileprovision_entry, tempfile.path){ override = true }
-				plist = Plist::parse_xml(`security cms -D -i #{tempfile.path}`)
+      tempfile = Tempfile.new(::File.basename(mobileprovision_entry.name))
+      begin
+        @ipa_zipfile.extract(mobileprovision_entry, tempfile.path) { override = true }
+        plist = Plist.parse_xml(`security cms -D -i #{tempfile.path}`)
 
-				plist.each do |key, value|
-					next if key == "DeveloperCertificates"
+        plist.each do |key, value|
+          next if key == 'DeveloperCertificates'
 
-					parse_value = nil
-					case value
-					when Hash
-						parse_value = value
-					when Array
-						parse_value = value
-					else
-						parse_value = value.to_s
-					end
+          parse_value = nil
+          parse_value = case value
+                        when Hash
+                          value
+                        when Array
+                          value
+                        else
+                          value.to_s
+                        end
 
-					result[:content][key] = parse_value
-				end
+          result[:content][key] = parse_value
+        end
 
-			rescue => e
-				puts e.message
-				result = nil
-			ensure
-				tempfile.close and tempfile.unlink
-			end
-			return result
-		end
+      rescue => e
+        puts e.message
+        result = nil
+      ensure
+        tempfile.close && tempfile.unlink
+      end
+      result
+    end
 
-		def collect_info_plist_info
-			raise "IPA is not open" unless self.open?
+    def collect_info_plist_info
+      collect_info_plist_info_from_file("#{@app_folder_path}/Info.plist")
+    end
 
-			result = {
-				path_in_ipa: nil,
-				content: {}
-			}
-			info_plist_entry = @ipa_zipfile.find_entry("#{@app_folder_path}/Info.plist")
+    def collect_info_plist_info_from_file(filename)
+      raise 'IPA is not open' unless open?
 
-			raise "File 'Info.plist' not found in #{@ipa_path}" unless info_plist_entry
-			result[:path_in_ipa] = "#{info_plist_entry}"
+      result = {
+        path_in_ipa: nil,
+        content: {}
+      }
+      info_plist_entry = @ipa_zipfile.find_entry(filename)
 
-			tempfile = Tempfile.new(::File.basename(info_plist_entry.name))
-			begin
-				@ipa_zipfile.extract(info_plist_entry, tempfile.path){ override = true }
-				# convert from binary Plist to XML Plist
-				unless system("plutil -convert xml1 '#{tempfile.path}'")
-					raise "Failed to convert binary Plist to XML"
-				end
-				plist = Plist::parse_xml(tempfile.path)
+      raise "File 'Info.plist' not found in #{@ipa_path}" unless info_plist_entry
+      result[:path_in_ipa] = info_plist_entry.to_s
 
-				plist.each do |key, value|
-					parse_value = nil
-					case value
-					when Hash
-						parse_value = value
-					when Array
-						parse_value = value
-					else
-						parse_value = value.to_s
-					end
+      tempfile = Tempfile.new(::File.basename(info_plist_entry.name))
+      begin
+        @ipa_zipfile.extract(info_plist_entry, tempfile.path) { override = true }
+        # convert from binary Plist to XML Plist
+        unless system("plutil -convert xml1 '#{tempfile.path}'")
+          raise 'Failed to convert binary Plist to XML'
+        end
+        plist = Plist.parse_xml(tempfile.path)
 
-					result[:content][key] = parse_value
-				end
+        plist.each do |key, value|
+          parse_value = nil
+          parse_value = case value
+                        when Hash
+                          value
+                        when Array
+                          value
+                        else
+                          value.to_s
+                        end
 
-			rescue => e
-				puts e.message
-				result = nil
-			ensure
-				tempfile.close and tempfile.unlink
-			end
-			return result
-		end
+          result[:content][key] = parse_value
+        end
 
+      rescue => e
+        puts e.message
+        result = nil
+      ensure
+        tempfile.close && tempfile.unlink
+      end
+      result
+    end
 
-		private
-		#
-		# Find the .app folder which contains both the "embedded.mobileprovision"
-		#  and "Info.plist" files.
-		def find_app_folder_in_ipa
-			raise "IPA is not open" unless self.open?
+    # List the frameworks used by the package
+    def collect_frameworks_info
+      raise 'IPA is not open' unless open?
 
-			# Check the most common location
-			app_folder_in_ipa = "Payload/#{File.basename(@ipa_path, File.extname(@ipa_path))}.app"
-			#
-			mobileprovision_entry = @ipa_zipfile.find_entry("#{app_folder_in_ipa}/embedded.mobileprovision")
-			info_plist_entry = @ipa_zipfile.find_entry("#{app_folder_in_ipa}/Info.plist")
-			#
-			if !mobileprovision_entry.nil? and !info_plist_entry.nil?
-				return app_folder_in_ipa
-			end
+      result = {
+        path_in_ipa: nil,
+        content: []
+      }
 
-			# It's somewhere else - let's find it!
-			@ipa_zipfile.dir.entries("Payload").each do |dir_entry|
-				if dir_entry =~ /.app$/
-					app_folder_in_ipa = "Payload/#{dir_entry}"
-					mobileprovision_entry = @ipa_zipfile.find_entry("#{app_folder_in_ipa}/embedded.mobileprovision")
-					info_plist_entry = @ipa_zipfile.find_entry("#{app_folder_in_ipa}/Info.plist")
+      frameworks_entries = @ipa_zipfile.glob("#{@app_folder_path}/Frameworks/*.framework")
 
-					if !mobileprovision_entry.nil? and !info_plist_entry.nil?
-						break
-					end
-				end
-			end
+      return nil if frameworks_entries.nil? || frameworks_entries.length.zero?
 
-			if !mobileprovision_entry.nil? and !info_plist_entry.nil?
-				return app_folder_in_ipa
-			end
-			return nil
-		end
-	end
+      result[:path_in_ipa] = "#{@app_folder_path}/Frameworks"
+
+      frameworks_entries.each do |fwk|
+        fwk_infoplist_filename = "#{fwk.name}Info.plist"
+        fwk_info = {
+          filename: fwk_infoplist_filename,
+          content: collect_info_plist_info_from_file(fwk_infoplist_filename)[:content]
+        }
+        result[:content].push(fwk_info)
+      end
+
+      result
+    end
+
+    # List the contents of the entitlements file included by the package (if any)
+    def collect_entitlements_info
+      raise 'IPA is not open' unless open?
+
+      result = nil
+
+      if !@ipa_zipfile.find_entry("#{@app_folder_path}/Entitlements.plist").nil?
+        result = collect_info_plist_info_from_file("#{@app_folder_path}/Entitlements.plist")
+      elsif !@ipa_zipfile.find_entry("#{@app_folder_path}/archived-expanded-entitlements.xcent").nil?
+        result = collect_info_plist_info_from_file("#{@app_folder_path}/archived-expanded-entitlements.xcent")
+      else
+        vputs 'INFO: No entitlements found'
+      end
+
+      result
+    end
+
+    private
+
+    #
+    # Find the .app folder which contains both the "embedded.mobileprovision"
+    #  and "Info.plist" files.
+    def find_app_folder_in_ipa
+      raise 'IPA is not open' unless open?
+
+      # Check the most common location
+      app_folder_in_ipa = "Payload/#{File.basename(@ipa_path, File.extname(@ipa_path))}.app"
+      #
+      mobileprovision_entry = @ipa_zipfile.find_entry("#{app_folder_in_ipa}/embedded.mobileprovision")
+      info_plist_entry = @ipa_zipfile.find_entry("#{app_folder_in_ipa}/Info.plist")
+      #
+      if !mobileprovision_entry.nil? && !info_plist_entry.nil?
+        return app_folder_in_ipa
+      end
+
+      # It's somewhere else - let's find it!
+      @ipa_zipfile.dir.entries('Payload').each do |dir_entry|
+        next unless dir_entry =~ /.app$/
+        app_folder_in_ipa = "Payload/#{dir_entry}"
+        mobileprovision_entry = @ipa_zipfile.find_entry("#{app_folder_in_ipa}/embedded.mobileprovision")
+        info_plist_entry = @ipa_zipfile.find_entry("#{app_folder_in_ipa}/Info.plist")
+
+        break if !mobileprovision_entry.nil? && !info_plist_entry.nil?
+      end
+
+      if !mobileprovision_entry.nil? && !info_plist_entry.nil?
+        return app_folder_in_ipa
+      end
+      nil
+    end
+  end
 end

--- a/lib/ipa_analyzer/analyzer.rb
+++ b/lib/ipa_analyzer/analyzer.rb
@@ -197,7 +197,7 @@ module IpaAnalyzer
         result[:info_plist] = collect_info_plist_info_with_path("#{fwk.name}Info.plist")[:content]
         result[:mobileprovision] = collect_provision_info_with_path(fwk.name)[:content]
         result[:entitlements] = collect_entitlements_info_with_path(fwk.name)[:content]
-        plugins = collect_watch_info_from_path("#{fwk.name}PlugIns/", '.appex')
+        plugins = collect_app_extensions_info_from_path("#{fwk.name}PlugIns/", '.appex')
         result[:plugins].concat(plugins) if !plugins.nil?
         result_list.push(result)
       end

--- a/lib/ipa_analyzer/version.rb
+++ b/lib/ipa_analyzer/version.rb
@@ -1,3 +1,3 @@
 module IpaAnalyzer
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end


### PR DESCRIPTION
This pull request is to include a couple more features to the gem to analyze the contents of:
* the entitlements file (if any)
* the frameworks located under the Frameworks folder (if any)

There's also a slight reformatting of the files to please Rubocop.