### PR TITLE
update rubyzip version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 source 'https://rubygems.org'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
+
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     ipa_analyzer (0.1.0)
       plist (~> 3.1, >= 3.1.0)
-      rubyzip (>= 1.1.7)
+      rubyzip (~> 1.1, >= 1.1.7)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,41 +3,43 @@ PATH
   specs:
     ipa_analyzer (0.1.0)
       plist (~> 3.1, >= 3.1.0)
-      rubyzip (~> 1.1.7, >= 1.1.7)
+      rubyzip (>= 1.1.7)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.3.0)
-    diff-lcs (1.2.5)
-    parser (2.4.0.0)
-      ast (~> 2.2)
-    plist (3.1.0)
-    powerpack (0.1.1)
-    rainbow (2.2.1)
-    rake (10.4.2)
-    rspec (3.2.0)
-      rspec-core (~> 3.2.0)
-      rspec-expectations (~> 3.2.0)
-      rspec-mocks (~> 3.2.0)
-    rspec-core (3.2.0)
-      rspec-support (~> 3.2.0)
-    rspec-expectations (3.2.0)
+    ast (2.4.0)
+    diff-lcs (1.3)
+    jaro_winkler (1.5.3)
+    parallel (1.17.0)
+    parser (2.6.3.0)
+      ast (~> 2.4.0)
+    plist (3.5.0)
+    rainbow (3.0.0)
+    rake (12.3.2)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.2)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.4)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.2.0)
-    rspec-mocks (3.2.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.2.0)
-    rspec-support (3.2.1)
-    rubocop (0.47.1)
-      parser (>= 2.3.3.1, < 3.0)
-      powerpack (~> 0.1)
-      rainbow (>= 1.99.1, < 3.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.2)
+    rubocop (0.72.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.6)
+      rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.8.1)
-    rubyzip (1.1.7)
-    unicode-display_width (1.1.3)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    ruby-progressbar (1.10.1)
+    rubyzip (1.2.3)
+    unicode-display_width (1.6.0)
 
 PLATFORMS
   ruby
@@ -49,4 +51,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   1.13.7
+   1.17.3

--- a/bin/ipa_analyzer
+++ b/bin/ipa_analyzer
@@ -1,9 +1,10 @@
+# frozen_string_literal: true
 #!/usr/bin/env ruby
 
 require 'optparse'
 require 'json'
 
-$:.push File.expand_path('../../lib', __FILE__)
+$:.push File.expand_path('../lib', __dir__)
 require 'ipa_analyzer'
 
 # -------------------------

--- a/ipa_analyzer.gemspec
+++ b/ipa_analyzer.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.description = 'Analyze an iOS .ipa file. Can be used as a CLI and can print the information in JSON so it can be used by other tools.'
 
   s.add_runtime_dependency 'plist', '~> 3.1', '>= 3.1.0'
-  s.add_runtime_dependency 'rubyzip', '>= 1.1.7'
+  s.add_runtime_dependency 'rubyzip', '~> 1.1', '>= 1.1.7'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop'

--- a/ipa_analyzer.gemspec
+++ b/ipa_analyzer.gemspec
@@ -1,5 +1,6 @@
-# -*- encoding: utf-8 -*-
-$:.push File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+$:.push File.expand_path('lib', __dir__)
 
 require 'ipa_analyzer/version'
 
@@ -17,9 +18,9 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'plist', '~> 3.1', '>= 3.1.0'
   s.add_runtime_dependency 'rubyzip', '~> 1.1', '>= 1.1.7'
 
+  s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop'
-  s.add_development_dependency 'rake'
 
   s.files         = Dir['./**/*'].reject { |file| file =~ %r{./(bin|log|pkg|script|spec|test|vendor)} }
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/ipa_analyzer.gemspec
+++ b/ipa_analyzer.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.description = 'Analyze an iOS .ipa file. Can be used as a CLI and can print the information in JSON so it can be used by other tools.'
 
   s.add_runtime_dependency 'plist', '~> 3.1', '>= 3.1.0'
-  s.add_runtime_dependency 'rubyzip', '~> 1.1.7', '>= 1.1.7'
+  s.add_runtime_dependency 'rubyzip', '>= 1.1.7'
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop'

--- a/lib/ipa_analyzer.rb
+++ b/lib/ipa_analyzer.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 require 'ipa_analyzer/version'
 require 'ipa_analyzer/analyzer'

--- a/lib/ipa_analyzer/version.rb
+++ b/lib/ipa_analyzer/version.rb
@@ -1,3 +1,5 @@
+#  frozen_string_literal: true
+
 module IpaAnalyzer
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.1.0'
 end

--- a/spec/analyzer_spec.rb
+++ b/spec/analyzer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative './../lib/ipa_analyzer/analyzer'
 
 describe IpaAnalyzer::Analyzer do
@@ -71,8 +73,8 @@ describe IpaAnalyzer::Analyzer do
       expect(content['UILaunchStoryboardName']).to eq('LaunchScreen')
       expect(content['UIMainStoryboardFile']).to eq('Main')
       expect(content['UIRequiredDeviceCapabilities']).to eq(['armv7'])
-      expect(content['UISupportedInterfaceOrientations']).to eq(%w(UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight))
-      expect(content['UISupportedInterfaceOrientations~ipad']).to eq(%w(UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight))
+      expect(content['UISupportedInterfaceOrientations']).to eq(%w[UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight])
+      expect(content['UISupportedInterfaceOrientations~ipad']).to eq(%w[UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight])
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
I hope to use rubyzip ~2.x.x~ 1.2.x, so I remove '~> 1.1.7'.
Pleaser you will merge and new version release.

I run rspec and all passed.
```
Finished in 0.13356 seconds (files took 0.49444 seconds to load)
2 examples, 0 failures
```
